### PR TITLE
Bugfix/remove quotes memberids

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/services/MemberServiceImpl.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/services/MemberServiceImpl.java
@@ -2,7 +2,6 @@ package com.lambdaschool.oktafoundation.services;
 import com.lambdaschool.oktafoundation.exceptions.ResourceNotFoundException;
 import com.lambdaschool.oktafoundation.models.Member;
 import com.lambdaschool.oktafoundation.repository.MemberRepository;
-import org.hibernate.annotations.ManyToAny;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,9 +9,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.module.ResolutionException;
 import java.util.ArrayList;
 import java.util.List;
+
 @Transactional
 @Service(value = "memberService")
 public class MemberServiceImpl implements MemberService
@@ -60,6 +59,8 @@ public class MemberServiceImpl implements MemberService
         String headerLine = reader.readLine();
         while((member = reader.readLine())!= null)
         {
+            // removes any quotes if needed from ends of memberid in CSV file
+            member = member.replaceAll("^\"|\"$", "");
 
             Member isCurrentMember = memberRepository.findMemberByMemberid(member);
             if ( isCurrentMember == null )

--- a/src/test/java/com/lambdaschool/oktafoundation/services/MemberServiceImplUnitTestNoDB.java
+++ b/src/test/java/com/lambdaschool/oktafoundation/services/MemberServiceImplUnitTestNoDB.java
@@ -120,7 +120,6 @@ public class MemberServiceImplUnitTestNoDB
 
     }
 
-    // new starts here
     @Test
     public void findMemberByJavaId()
     {


### PR DESCRIPTION
- What work was done?
Logic was added to the MemberServiceImpl file to remove any quotes from the ends of the memberid strings passed into the saveNewMembers method in a CSV file.

- Why was this work done?
 I realized the memberids from the CSV file were being added to the member database table with enclosing quotes. I added this code to remove quotes if any, before adding the id to the member database table.

- What feature / user story is it for?
As a Super Admin or Club Director, I want to import new kid member id numbers into the app using a CSV file.

- Any relevant links or images / screenshots

- User story link [Trello card](https://trello.com/c/Hnu7rpSi)

## Type of change

- [ ] New feature
- [ x ] Bug fix
- [ ] Design change
- [ ] Modified existing code


## Minimum reviewers
- [  x ] 2 reviewers Mike, Sable, Justin

## Testing
- [  x ] Testing completed - All tests on the class are still passing after the added code.