### PR TITLE
bugfix/clubid

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/models/ClubPrograms.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/models/ClubPrograms.java
@@ -62,7 +62,7 @@ public class ClubPrograms
             return false;
         }
         ClubPrograms that = (ClubPrograms) o;
-        return ((club == null) ? 0 : club.getId()) == ((that.club == null) ? 0 : that.club.getId()) &&
+        return ((club == null) ? 0 : club.getClubid()) == ((that.club == null) ? 0 : that.club.getClubid()) &&
             ((program == null) ? 0 : program.getProgramid()) == ((that.program == null) ? 0 : that.program.getProgramid());
     }
 


### PR DESCRIPTION
## Description: 
- What work was done?
The getter for the clubid needed to be getClubid instead of getId in the clubsprograms equals method

- Why was this work done?
 This fixes a bug created by a naming difference for the clubid in the clubprograms model

- What feature / user story is it for?
As a YDP, Club Director, or Super Admin I want to be able to store and access program data within the application

- Any relevant links or images / screenshots

- User story link  [Trello card](https://trello.com/c/uDC7MMcu)

## Type of change

- [ ] New feature
- [ x ] Bug fix
- [ ] Design change
- [ ] Modified existing code


## Minimum reviewers
- [ x  ] 2 reviewers Mike and Justin 

## Testing
- [ ] Testing completed